### PR TITLE
Allow to use different API

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -12,8 +12,8 @@ export function startIPFS() {
   return new Promise(success => {
     if (IPFS_CLIENT != null) return success(IPFS_CLIENT)
 
-    const api_multiaddr = getMultiAddrIPFSDaemon() || '/ip4/127.0.0.1/tcp/5001'
-    IPFS_CLIENT = ipfsAPI(api_multiaddr)
+    const apiMultiaddr = getMultiAddrIPFSDaemon()
+    IPFS_CLIENT = ipfsAPI(apiMultiaddr)
     window.ipfs = IPFS_CLIENT
     // Somehow this is not always working
     return success(IPFS_CLIENT)

--- a/app/daemon.js
+++ b/app/daemon.js
@@ -32,6 +32,11 @@ export function startIPFSCommand() {
  * Returns the multiAddr usable to connect to the local dameon via API
  */
 export function getMultiAddrIPFSDaemon() {
+  // If the user specified a value in the multiaddrAPI
+  const settingsAddress = Settings.getSync('daemon.multiAddrAPI')
+  if (settingsAddress) return settingsAddress
+
+  // Otherwise ask the binary wich one to use
   const binaryPath = getPathIPFSBinary()
   const multiAddr = execSync(`${binaryPath} config Addresses.API`)
   return `${multiAddr}`


### PR DESCRIPTION
Moves the logic of choosing the address to use to connect, only in
`getMultiAddrIPFSDaemon`, so we can define the API to use.

Tested using a RaspberryPi node on the same network.

closes #28 